### PR TITLE
fix(bundle): only include necessary files in package bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,11 @@
     "url": "https://github.com/twozeroone/post-type-discovery/issues"
   },
   "homepage": "https://github.com/twozeroone/post-type-discovery#readme",
+  "files": [
+    "/README.md",
+    "/index.js",
+    "/LICENSE"
+  ],
   "dependencies": {
     "html-to-text": "^4.0.0",
     "valid-url": "^1.0.9"


### PR DESCRIPTION
Adds `files` to `package.json`

This prevents development files from being included in the published build, bloating the package:

![image](https://user-images.githubusercontent.com/12508200/82440263-f46ee600-9a93-11ea-9d26-45a04fb5558b.png)

The sizes is mostly from the inclusion of font files in the `docs` folder.

This reduces the unpacked size to ~ 8kb